### PR TITLE
Only modify Version registry detection method

### DIFF
--- a/Invoke-OPPContentUpdate.ps1
+++ b/Invoke-OPPContentUpdate.ps1
@@ -205,7 +205,7 @@ Process {
     
                                                     try {
                                                         # Construct string array with logical name of enhanced detection method registry name
-                                                        [string[]]$OfficeApplicationDetectionMethodLogicalName = ([xml]$OfficeDeploymentType.SDMPackageXML).AppMgmtDigest.DeploymentType.Installer.CustomData.EnhancedDetectionMethod.Settings.SimpleSetting.LogicalName
+                                                        ([xml]$OfficeDeploymentType.SDMPackageXML).AppMgmtDigest.DeploymentType.Installer.CustomData.EnhancedDetectionMethod.Settings.SimpleSetting | where DataType -eq 'Version' | Select-Object LogicalName
                                                         Write-Verbose -Message "Enhanced detection method logical name for existing registry detection clause was determined as: $($OfficeApplicationDetectionMethodLogicalName)"
     
                                                         # Remove existing detection method and add new with updated version info


### PR DESCRIPTION
Currently, the script removes *all* registry detection rules and replaces them with a single version rule. This shot me in the foot because we install Office 365 with one app, and then Visio & Project are separate installers for those with the licenses.
If the Application *only* detects based on Version, it sees the necessary version string from the main Office 365, and thinks Project/Visio are already installed.
The easiest solution for that was a **second** registry detection rule for Project/Visio.
This PR modifies the script to **only** replace the registry rule looking at the Version